### PR TITLE
Added a tag search system and added adult.html which includes sites with adult tag.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,3 @@
 node_modules**
-
 index.html
+adult.html

--- a/build.js
+++ b/build.js
@@ -2,57 +2,331 @@ import fs from "fs"
 import yaml from "yaml"
 import {marked} from "marked"
 
-
-let directory = yaml.parse(fs.readFileSync('./directory.yml', 'utf8'));
-
-let sites = {};
-let siteList = yaml.parse(fs.readFileSync('./sites.yml', 'utf8'));
-let sitesNotListed = new Set();
-let sitesNotCompiled = new Set();
-
-let adultContent = fs.existsSync("./.ADULT")
-
-for(let site of siteList)
+function BuildSiteElement(site_data)
 {
-	if(site.name == "" || site.name == null)
-		continue;
-
-	if(sites[site.name])
-		throw new Error("Site " + site.name + " was already added.")
-
-	sites[site.name] = site;
-	sitesNotListed.add(site.name)
+	const protocol = "//";
+	//XXX: Use this when testing locally (without a web server).
+	//const protocol = "https://";
+	
+	const GetUrl = (link) => {
+		if (link.indexOf("://") >= 0) {
+			return link;
+		}
+		return protocol + link;
+	};
+	
+	const GetTagLabelGroupingClass = (idx_tag, tags) => {
+		if (tags.length > idx_tag + 1 && tags[idx_tag + 1][0].startsWith(tags[idx_tag][0] + ":")) {
+			return "tag-label-start";
+		}
+		else if (tags[idx_tag][0].indexOf(":") >= 0) {
+			if (tags.length <= idx_tag + 1 || tags[idx_tag + 1][0].indexOf(":") < 0) {
+				return "tag-label-end";
+			}
+			else {
+				return "tag-label-middle";
+			}
+		}
+		else {
+			return "";
+		}
+	};
+	
+	return `\
+<div class="site-container ${site_data.tags.has("dead") ? "dead" : ""}" data-tags="${Array.from(site_data.tags.keys()).join(",")}" >
+	<div>
+		<div class="site-title" >${site_data.name}</div>
+		<span class="site-updated" >Checked on ${site_data.updated}</span>
+	</div>
+	<div class="site-body-container" >
+		<div class="site-link-container" >
+` + (site_data.link == undefined
+? ""
+: `			<a class="site-link" href="${GetUrl(site_data.link)}" >${site_data.link}</a>
+`) + `\
+` + (site_data.description == undefined
+? ""
+: `			<div class="site-description" >${site_data.description}</div>
+`) + `\
+		</div>
+` + Array.from(site_data.links.values()).map((link_data) => `\
+		<div class="site-link-container ${link_data.is_dead ? "dead" : ""}" >
+			<a class="site-link" href="${GetUrl(link_data.link)}" >${link_data.link}</a>
+` + (link_data.description == undefined
+? ""
+: `			<div class="site-description" >${link_data.description}</div>
+`) + `\
+		</div>
+`).join("") + `\
+		<div>
+` + Array.from(site_data.tags).map((tag_data, idx_tag, tags) => `\
+<div class="tag-label ${GetTagLabelGroupingClass(idx_tag, tags)}" name="${tag_data[0]}" >${tag_data[1].name}</div>\
+`).join("") + `\
+		</div>
+	</div>
+</div>
+`;
 }
 
-let struct = buildStructure(directory.body);
-
-// Parse TOC
-let siteText = flatten(stripSitelessNodes(buildStructure(directory.body)));
-
-let nav = toTOC(stripSitelessNodes(buildStructure(directory.body)));
-
-if(adultContent)
-	siteText = siteText.replace("{{intro}}", directory.intro_ad)	
-else
-	siteText = siteText.replace("{{intro}}", directory.intro)	
-
-
-let siteMatch = /{{(.*?)}}/.exec(siteText)
-
-while(siteMatch)
+function BuildTagElement(tag_data)
 {
-	siteText = siteText.replace(siteMatch[0], buildSite(siteMatch[1]))
-	siteMatch = /{{(.*?)}}/.exec(siteText)
+	return `\
+<div class="tag-container" >
+	<label><input type="checkbox" name="${tag_data.tag}" onclick="CheckboxToggleIndeterminate(this)" onchange="ToggleTag(this)" autocomplete="off" indeterminate /> ${tag_data.name}</label>
+` + (tag_data.description == undefined
+? ""
+: `	<div class="tag-description" >${tag_data.description}</div>
+`) + (
+tag_data.subtags.size <= 0 ? "" : `\
+	<div class="tag-subtag-container" >
+` + Array.from(tag_data.subtags.values()).map((subtag_data) => `\
+		<label><input type="checkbox" name="${subtag_data.id}" onclick="CheckboxToggleIndeterminate(this)" onchange="ToggleTag(this)" autocomplete="off" indeterminate /> ${subtag_data.name}</label>
+`).join("") + `\
+	</div>
+`) + `\
+</div>
+`;
 }
 
-if(sitesNotListed.size > 0)
+function ParseTags()
 {
-	console.log([...sitesNotListed])
-	throw new Error("Not all registered sites are on the list")
+	let fileTextTags = fs.readFileSync('./tags.yml', 'utf8');
+	let dataTags = yaml.parse(fileTextTags);
+	
+	const tags = new Map();
+	
+	let tagOrderId = 0;
+	
+	for (const tag of dataTags) {
+		if (tag.tag == undefined) {
+			continue;
+		}
+		let tagData = {
+			tag: tag.tag,
+			name: tag.name,
+			id: tag.tag,
+			order_id: ++tagOrderId,
+			description: tag.description,
+			subtags: new Map(),
+		};
+		if (tagData.name == undefined) {
+			throw new Error(`Tag ${tagData.tag} does not have a name.`);
+		}
+		if (tag.subtags != undefined) {
+			for (const subtag of tag.subtags) {
+				if (subtag.tag == undefined) {
+					continue;
+				}
+				let subtagData = {
+					tag: subtag.tag,
+					name: subtag.name,
+					id: `${tagData.tag}:${subtag.tag}`,
+					order_id: ++tagOrderId,
+				};
+				if (subtagData.name == undefined) {
+					throw new Error(`Tag ${subtag.id} does not have a name.`);
+				}
+				if (tagData.subtags.has(tagData.tag)) {
+					throw new Error(`Tag ${subtag.id} already exists.`);
+				}
+				tagData.subtags.set(subtag.tag, subtagData);
+			}
+		}
+		
+		if (tags.has(tagData.tag)) {
+			throw new Error(`Tag ${tagData.tag} already exists.`);
+		}
+		tags.set(tagData.tag, tagData);
+	}
+	
+	return tags;
 }
 
+function ParseSites(tags)
+{
+	let fileTextSites = fs.readFileSync('./sites.yml', 'utf8');
+	let dataSites = yaml.parse(fileTextSites);
+	
+	const sites = new Map();
+	
+	const all_links = new Set();
+	const CheckLink = (link) => {
+		if (link == undefined) {
+			return false;
+		}
+		
+		if (all_links.has(link)) {
+			console.error(`WARNING: The link "${link}" has already been used in another site entry.`);
+			return false;
+		}
+		
+		all_links.add(link);
+		return true;
+	}
+	
+	for (const site of dataSites) {
+		if (site.name == undefined) {
+			continue;
+		}
+		let siteData = {
+			name: site.name,
+			description: site.description,
+			tags: new Map(),
+			link: site.link,
+			links: new Map(),
+			updated: site.updated,
+		};
+		
+		CheckLink(siteData.link);
+		
+		if (site.links !== undefined) {
+			for (const link of site.links) {
+				if (link.link == undefined) {
+					continue;
+				}
+				let linkData = {
+					link: link.link,
+					description: link.description,
+					is_dead: link.is_dead ?? false,
+				};
+				
+				if (siteData.links.has(linkData.link) || siteData.link == linkData.link) {
+					throw new Error(`Site "${siteData.name}" already contains the link: "${linkData.link}".`);
+				}
+				CheckLink(linkData.link);
+				siteData.links.set(linkData.link, linkData);
+			}
+		}
+		
+		const unparsedTags = site.tags?.split(",").map((tag) => tag.split(":").filter((tag) => tag.length > 0)).filter((tag) => tag.length > 0) ?? [];
+		for (const siteTag of unparsedTags) {
+			const tag = tags.get(siteTag[0]);
+			if (tag == undefined) {
+				throw new Error(`Site "${siteData.name}" tag "${siteTag[0]}" does not exist.`);
+			}
+			siteData.tags.set(tag.tag, tag);
+			
+			for (const siteSubtag of siteTag.slice(1)) {
+				const subtag = tag.subtags.get(siteSubtag);
+				if (subtag == undefined) {
+					throw new Error(`Site "${siteData.name}" tag "${tag.tag}:${siteSubtag}" does not exist.`);
+				}
+				
+				siteData.tags.set(subtag.id, subtag);
+			}
+		}
+		
+		if (siteData.tags.size <= 0) {
+			throw new Error(`Site "${siteData.name}" does not have any tags.`);
+		}
+		
+		if (siteData.link == undefined && siteData.links.size <= 0) {
+			throw new Error(`Site "${siteData.name}" does not have any links.`);
+		}
+		
+		if (siteData.updated == undefined) {
+			throw new Error(`Site "${siteData.name}" last updated date not set.`);
+		}
+		
+		if (sites.has(siteData.name)) {
+			throw new Error(`Site "${siteData.name}" already exists.`);
+		}
+		sites.set(siteData.name, siteData);
+	}
+	
+	return sites;
+}
 
-let html = `
+(function () {
+	const tags = ParseTags();
+	const sites = ParseSites(tags);
+	
+	let fileTextPage = fs.readFileSync('./directory.yml', 'utf8');
+	let dataPage = yaml.parse(fileTextPage);
+	
+	for (const adultContent of [false, true]) {
+		let navHeadings = [];
+		const AddNavHeading = (tag_data) => {
+			let leftPadding = 5;
+			if (tag_data.id.indexOf(":") >= 0) {
+				leftPadding += 25;
+			}
+			navHeadings.push(`\
+<a style="padding-left: ${leftPadding}px" href="#${tag_data.id}">${tag_data.name}</a>
+`);
+		};
+		
+		let lastTagId = "";
+		const GetSortingTag = (site_data) => {
+			const itrTag = site_data.tags.values();
+			const tag1 = itrTag.next().value;
+			const tag2 = itrTag.next().value;
+			
+			if ((tag2?.id.indexOf(":") ?? -1) >= 0) {
+				return tag2;
+			}
+			return tag1;
+		};
+		let htmlSites = Array
+			.from(sites.values())
+			.filter((site_data) => adultContent || !site_data.tags.has("adult"))
+			.sort((site_1, site_2) => GetSortingTag(site_1).order_id - GetSortingTag(site_2).order_id)
+			.map((site_data) => {
+				const siteHtml = BuildSiteElement(site_data);
+				const siteMainTagId = GetSortingTag(site_data).id;
+				let result = siteHtml;
+				if (lastTagId !== siteMainTagId) {
+					const tagParts = siteMainTagId.split(":");
+					const lastTagParts = lastTagId.split(":");
+					const BuildMajorHeading = (tag_id) => {
+						const tagData = tags.get(tag_id);
+						AddNavHeading(tagData);
+						return `\
+<div id="${tagData.id}" >
+	<h1>${tagData.name}</h1>
+` + (tagData.description == undefined
+? ""
+: `	<p>${tagData.description}</p>
+`) + `\
+</div>
+`;
+					};
+					const BuildMinorHeading = (tag_id) => {
+						const tagParts = tag_id.split(":");
+						const tagData = tags.get(tagParts[0]);
+						const subtagData = tagData.subtags.get(tagParts[1]);
+						AddNavHeading(subtagData);
+						return `\
+<div id="${subtagData.id}" >
+	<h2>${subtagData.name}</h2>
+</div>
+`;
+					};
+					let majorHeading = "";
+					let minorHeading = "";
+					if (tagParts.length > 1 && lastTagParts[0] !== tagParts[0]) {
+						majorHeading = BuildMajorHeading(tagParts[0]);
+					}
+					if (tagParts.length > 1) {
+						minorHeading = BuildMinorHeading(siteMainTagId);
+					}
+					else {
+						majorHeading = BuildMajorHeading(siteMainTagId);
+					}
+					lastTagId = siteMainTagId;
+					result = majorHeading + minorHeading + result;
+				}
+				return result;
+			})
+			.join("");
+		
+		let htmlTags = Array
+			.from(tags.values())
+			.filter((tag_data) => adultContent || tag_data.tag !== "adult")
+			.map((tag_data) => BuildTagElement(tag_data))
+			.join("");
+		
+		let html = `\
 <!DOCTYPE html>
 <html>
 	<head>
@@ -62,191 +336,29 @@ let html = `
 		<div id='background' class="${adultContent ? "adult" : ""}"></div>
 		<nav>
 			<strong>Table of Contents</strong>
-			${nav}
+			${navHeadings.join("")}
 		</nav>
 		<main>
-			${marked.parse(siteText)}
+			${marked.parse(adultContent ? dataPage.intro_ad : dataPage.intro)}
+			<label><input type="checkbox" id="SimpleFilterDead" onchange="ToggleDeadWebsites(this)" autocomplete="off" checked /> Show dead websites</label>
+			<div>
+				<h1>Advanced Filters</h1>
+				<input type="button" class="tags-reset-button" onclick="ResetAllTags(this)" value="Reset Tag Filters" />
+				<input type="button" class="tags-visibility-button" onclick="ToggleTagFiltersVisibility(this)" value="Show/Hide Filters" />
+				<div id="TagsContainer" class="tag-filters tag-filters-hide" >
+					${htmlTags}
+				</div>
+			</div>
+			<h1>Fan Works</h1>
+			<div id="SitesContainer" >
+				${htmlSites}
+			</div>
 		</main>
 		<script src="index.js"></script>
 	</body>
 </html>
 `;
-
-
-fs.writeFileSync('./index.html', html, 'utf8');
-
-
-function buildSite(siteName)
-{
-	let siteData = sites[siteName];
-
-	if(!siteData)
-	{
-		throw new Error("Site " + siteName + " is not included in sites.yml")
+		
+		fs.writeFileSync(adultContent ? "./adult.html" : "./index.html", html, "utf8");
 	}
-
-	if((siteData.is_adult && !adultContent) || (!siteData.is_adult && adultContent))
-		return "";
-
-	
-	let classes = "";
-
-	if(siteData.is_dead)
-		classes += " dead";
-	if(siteData.is_adult)
-		classes += " adult";
-
-	let protocol = "https://"
-	if(siteData.no_https)
-		protocol = "http://"
-
-	return `<div class="${classes}">
-	    <a class='site' href="${protocol + siteName}">${siteName}</a>
-	    <span>${siteData.description}</span>
-	    <span class='updated'>Checked on ${siteData.updated}</span>
-	  </div>`
-}
-
-function buildStructure(text)
-{
-	let lines = text.split("\n")
-
-	let currentStructure = {level:0, children: [], text:""};
-
-	for(let line of lines)
-	{
-		let s = line.trim()
-		if(s.startsWith("#"))
-		{	
-			let level=1
-			while(s[level] == "#")
-				level++;
-
-			let newStructure = {
-				type: "heading",
-				level,
-				text: line,
-				children: []
-			}
-
-			while(currentStructure.level >= level)
-				currentStructure = currentStructure.parent;
-
-			newStructure.parent = currentStructure;
-			currentStructure.children.push(newStructure);
-			currentStructure = newStructure;
-		}
-		else if (s.startsWith("{"))
-		{
-			let siteName = s.replace(/\{|\}/g,"").trim();
-
-			if(!sites[siteName])
-			{
-				currentStructure.children.push({type: "text", text: line})
-				continue;
-			}
-
-			sitesNotListed.delete(siteName)
-
-			if((adultContent && sites[siteName].is_adult) || (!adultContent && !sites[siteName].is_adult))
-			{
-				currentStructure.children.push({type: "site", text: line})
-			}
-		}
-		else
-		{
-			currentStructure.children.push({type: "text", text: line})
-		}
-	}
-
-	while(currentStructure.level != 0)
-		currentStructure = currentStructure.parent;
-
-	return currentStructure;
-}
-
-function stripSitelessNodes(node)
-{
-	if(node.type == "text")
-		return node;
-	if(node.type == "site")
-		return node;
-
-	for(let i=0; i < node.children.length; i++)
-	{
-		if(node.children[i].type == "text")
-			continue;
-		if(node.children[i].type == "site")
-			continue;
-
-		stripSitelessNodes(node.children[i]);
-
-		if(!hasSites(node.children[i]))
-		{
-			node.children.splice(i,1);
-			i--
-		}
-	}
-
-	return node;
-}
-
-function flatten(node)
-{
-	if(node.type == "text" || node.type == "site")
-		return node.text + "\n";
-
-	let headingHTML = "";
-	if(node.level > 0)
-	{
-		let text = node.text.replace(/#/g,"").trim();
-		let tag = "h"+node.level
-		headingHTML= `<${tag} id="${getHeadingAnchor(node.text)}">${text}</${tag}>`;
-	}
-
-	return headingHTML + node.children.map(x => flatten(x)).join("");
-}
-
-function getHeadingAnchor(text)
-{
-	text = text.replace(/#/g,"").trim();
-	return text.replace(/[^A-Za-z0-9 ]/g,"").replace(/ +/g,"_")
-}
-
-function toTOC(node)
-{
-	if(node.type == "text" || node.type == "site")
-		return "";
-
-	let section = node.text.replace(/#/g,"").trim();
-
-	let sectionLink = getHeadingAnchor(node.text);
-
-	let thisNode = node.level == 0 ? "" : `<a style="padding-left: ${node.level*25-20}px" href="#${sectionLink}">${section}</a>\n`
-
-
-	return thisNode+ node.children.map(toTOC).join("")
-
-}
-
-function hasSites(node)
-{
-	if(node.type == "text")
-	{
-		return false;
-	}
-	if(node.type == "site")
-	{
-		return true;
-	}
-
-	for(let k of node.children)
-	{
-		if(hasSites(k))
-		{
-			return true;
-		}
-	}
-
-	return false;
-}
+})();

--- a/directory.yml
+++ b/directory.yml
@@ -1,175 +1,18 @@
+
 intro: |
   <div class='title'>Welcome to the Herd!</div>
 
   The My Little Pony fandom is huge and contains many website dedicated to fan content! 
   Below you'll find an index of many different sites.
-
-intro_ad: |
-  Oh, so you're looking for the other stuff... well you've come to the right place.
-
-  The main list of all MLP websites is [here](https://www.pony.directory). These are the websites in the MLP fandom that are for adult eyes only.
-
-body: |
-  {{intro}}
   
   If a website is missing or the link no longer works, please let brambleshadow4 know via Discord or twitter.
   Better yet, head to our [github](https://github.com/brambleshadow4/pony-directory) and submit a pull request with the change you'd like to make.
 
-  <div>
-    <input type="checkbox" id='dead'/><label for="dead">Show dead websites</label>  
-  </div>
+intro_ad: |
+  <div class='title'>Welcome to the ...</div>
+  Oh, so you're looking for the other stuff... well you've come to the right place.
 
-  # Fan Works #
-
-  ## Blogs ##
-  {{www.equestriadaily.com}}
-  {{www.horse-news.org}}
-  {{www.dailydoseofpony.com}}
-
-  ## Art ## 
-  {{www.derpibooru.org}}
-  {{www.canterlotcomics.com}}
-  {{boards.4channel.org/mlp/}}
-
-  ### Derpibooru Alternates ###
-
-  {{manebooru.art}}
-  {{www.bronibooru.com}}
-
-  ## Music ##
-
-  {{horsemusicherald.com}}
-  {{ponyvillefm.com}}
-  {{ponymusic.wiki}}
-  {{pony.fm}}
-  {{noise.horse}}
-  {{ponemusic.net}}
-
-  {{sogreatandpowerful.com}}
-
-  ## Fanfiction ##
-
-  {{www.fimfiction.net}}
-  {{www.ponyfictionarchive.net}}
-
-  ### Printing ###
-  {{www.ministryofimage.net}}
-
-  ## Board + Video Games ##
-
-  {{pony.town}}
-  {{poniarcade.com}}
-  {{ponytone.online}}
-  {{www.cardsagainstequestria.horse}}
-  {{mylittlegamedev.com}}
-
-  {{www.equestriagaming.net}}
-  {{www.mylittlekaraoke.com}}
-
-  ### Secret Shipfic Folder ###
-
-  {{www.secretshipfic.com}}
-  {{www.tsssf.net}}
-  {{childrenofkefentse.com}}
-
-  ## Archives ##
-
-  {{www.theponyarchive.com}}
-  {{projectvinyl.net}}
-
-  ## Other ##
-  {{www.whatisabrony.com}}
-  {{bronyshow.com}}
-  {{ponepaste.org}}
-  {{pony.community}}
-  {{equestria.dev}}
+  The main list of all MLP websites is [here](https://www.pony.directory). These are the websites in the MLP fandom that are for adult eyes only.
   
-  # Conventions #
-
-  {{ponycon.info}}
-
-  ## North America ##
-
-  {{www.babscon.com}}
-  {{ponyvilleciderfest.com}}
-  {{mlp-msp.com}}
-  {{everfreenw.com}}
-  {{www.harmonycon.org}}
-  {{trotcon.net}}
-  {{whinnycity.com}}
-  {{bronycan.ca}}
-  {{marefair.org}}
-
-  ## Europe ##
-
-  {{everfree-encore.eu}}
-  {{eponafest.it}}
-  {{galacon.pony-events.eu}}
-  {{www.czequestria.cz}}
-  {{ponyconholland.com}}
-
-  ## International Cons ##
-
-  {{seaponycon.com}}
-  {{www.aliconmlp.com}}
-
-  ## Online Cons ##
-
-  {{ponyfest.horse}}
-
-  # Communities #
-
-  {{greattobedifferent.com}}
-  {{ponies.equestria.horse}}
-  {{pony.dev}}
-  
-  ## Streaming ##
-  {{www.bronystate.net}}
-  {{www.bronytv.net}}
-  {{cinemaquestria.com}}
-  {{equestria.tv}}
-  {{ponyvillelive.com}}
-
-  ## Forums + Roleplaying ##
-  {{mlpforums.com}}
-  {{www.roundstable.com}}
-  {{mlponies.com}}
-  {{www.redlightponyville.com}}
-  {{www.canterlot.com}}
-
-  ## Fediverse + Mastodon ##
-
-  {{fedi.ponysearch.eu}}
-
-  ## International ##
-  {{mlp-france.com}}
-  {{www.ponylatino.com}}
-  
-  ## Wikis ##
-
-  {{mlp.fandom.com}}
-  {{mlpfanart.fandom.com}}
-  {{ponymusic.wiki}}
-  
-  ## Poniverse ##
-
-  {{poniverse.net}}
-  {{canterlotavenue.com}}
-
-  # Joke Sites #
-  {{www.starlightglimmer2020.com}}
-  {{celestianism.com}}
-  {{www.bbbff.net}}
-
-  # Personal Sites #
-
-  {{www.littleshyfim.com}}
-  {{lighttheunicorn.horse}}
-
-  ## Vylet Pony ##
-
-  {{www.vyletpony.com}}
-  {{cutiemarks.net}}
-  {{antonymph.com}}
-  {{trixielulamoon.com}}
-  {{starshipponyville.com}}
+  If a website is missing or the link no longer works, please let brambleshadow4 know via Discord or twitter.
+  Better yet, head to our [github](https://github.com/brambleshadow4/pony-directory) and submit a pull request with the change you'd like to make.

--- a/index.css
+++ b/index.css
@@ -8,7 +8,6 @@
   src: url(./font/Roboto-Regular.ttf);
 }
 
-
 nav {
 	font-family: Roboto;
 	position: fixed;
@@ -16,12 +15,13 @@ nav {
 	padding: 5px 10px;
 }
 
-
-
 nav a {
 	display: block;
 }
 
+div {
+	
+}
 
 #background.adult {
 	background-image: url(./img/Canterlot_night.webp);
@@ -77,28 +77,106 @@ main
 	}
 }
 
-div {
-	clear: right;
+.tags-reset-button, .tags-visibility-button {
+	display: block;
+	margin-top: 10px;
+	margin-bottom: 10px;
 }
 
-.updated {
+.tag-filters-hide {
+	display: none;
+}
+
+.tag-filters {
+}
+
+.tag-container {
+	display: block;
+}
+
+.tag-description {
+	display: block;
+	padding-left: 25px;
+}
+
+.tag-subtag-container {
+	display: block;
+	padding-left: 25px;
+}
+
+.tag-label {
+	display: inline-block;
+	padding-left: 4px;
+	padding-right: 4px;
+	border: 1px solid #000;
+	border-radius: 4px;
+	margin-right: 4px;
+}
+
+.tag-label-start {
+	margin-right: 0px;
+	border-top-right-radius: 0px;
+	border-bottom-right-radius: 0px;
+	border-right: 0px;
+}
+
+.tag-label-middle {
+	margin-left: 0px;
+	margin-right: 0px;
+	border-radius: 0px;
+	border-right: 0px;
+}
+
+.tag-label-end {
+	margin-left: 0px;
+	border-top-left-radius: 0px;
+	border-bottom-left-radius: 0px;
+}
+
+.site-container {
+	display: block;
+	margin-bottom: 10px;
+}
+
+.site-updated {
 	float: right;
 	color: #B0B0B0;
 }
 
-.dead {
+.site-title {
+	display: inline-block;
+	font-size: 18px;
+	font-weight: 700;
+}
+
+.site-body-container {
+	display: block;
+	padding-left: 10px;
+}
+
+.site-link-container {
+	display: block;
+}
+
+.site-link {
+	display: inline-block;
+	margin-right: 10px;
+}
+
+.site-description {
+	display: inline-block;
+}
+
+.hide-site {
+	display: none;
+}
+
+.dead div {
 	text-decoration: line-through;
 	color: red;
 }
 
 .dead a {
+	text-decoration: line-through;
 	color: red;
-}
-
-.dead {
-	display: none;
-}
-
-.show_dead .dead {
-	display: block;
 }

--- a/index.js
+++ b/index.js
@@ -1,13 +1,184 @@
-let showDead = document.getElementById('dead')
 
-dead.onchange = function(e)
+function CheckboxToggleIndeterminate(element_action)
 {
-	if(dead.checked)
-	{
-		document.body.classList.add('show_dead')
+	if (element_action.readOnly) {
+		element_action.readOnly = false;
+		element_action.checked = true;
 	}
-	else
-	{
-		document.body.classList.remove("show_dead");
+	else if (element_action.checked) {
+		element_action.indeterminate = true;
+		element_action.readOnly = true;
 	}
 }
+
+function ToggleTagFiltersVisibility(element_action)
+{
+	const elementTagsContainer = document.getElementById("TagsContainer");
+	const hideClassName = "tag-filters-hide";
+	
+	const showFilters = elementTagsContainer.classList.contains(hideClassName);
+	
+	if (showFilters) {
+		elementTagsContainer.classList.remove(hideClassName);
+	}
+	else {
+		elementTagsContainer.classList.add(hideClassName);
+	}
+}
+
+function ToggleDeadWebsites(element_action)
+{
+	const elementTagsContainer = document.getElementById("TagsContainer");
+	const elementTagDead = elementTagsContainer.querySelectorAll("input[name='dead']")[0];
+	
+	if (element_action.checked) {
+		elementTagDead.readOnly = true;
+		elementTagDead.checked = false;
+		elementTagDead.indeterminate = true;
+	}
+	else {
+		elementTagDead.readOnly = false;
+		elementTagDead.checked = false;
+		elementTagDead.indeterminate = false;
+	}
+	
+	ToggleTag();
+}
+
+function ResetAllTags(element_action)
+{
+	const elementTagsContainer = document.getElementById("TagsContainer");
+	const elementsTags = elementTagsContainer.querySelectorAll("input[type='checkbox']");
+	
+	for (const elementTag of elementsTags) {
+		elementTag.checked = false;
+		elementTag.readOnly = true;
+		elementTag.indeterminate = true;
+	}
+	
+	const elementSimpleFilterDead = document.getElementById("SimpleFilterDead");
+	elementSimpleFilterDead.checked = true;
+	
+	ToggleTag();
+}
+
+function ToggleTag()
+{
+	const elementTagsContainer = document.getElementById("TagsContainer");
+	const elementSitesContainer = document.getElementById("SitesContainer");
+	const elementsTags = elementTagsContainer.querySelectorAll("input[type='checkbox']");
+	
+	const tagsOn = new Set();
+	const tagsOff = new Set();
+	
+	for (const elementTag of elementsTags) {
+		if (elementTag.indeterminate) {
+			continue;
+		}
+		let tagName = elementTag.getAttribute("name");
+		if (elementTag.checked) {
+			tagsOn.add(tagName);
+		}
+		else {
+			tagsOff.add(tagName);
+		}
+	}
+	
+	let previousHeadingTag = undefined;
+	let previousHeadingTagHasVisibleInside = false;
+	let previousHeadingSubtag = undefined;
+	let previousHeadingSubtagHasVisibleInside = false;
+	
+	const ProcessHeader = (elementSiteContainer) => {
+		const isSubtag = (elementSiteContainer?.id.indexOf(":") ?? -1) >= 0;
+		
+		const hideClassName = "hide-site";
+		if (previousHeadingSubtag !== undefined) {
+			if (!previousHeadingSubtagHasVisibleInside) {
+				if (!previousHeadingSubtag.classList.contains(hideClassName)) {
+					previousHeadingSubtag.classList.add(hideClassName);
+				}
+			}
+			else {
+				if (previousHeadingSubtag.classList.contains(hideClassName)) {
+					previousHeadingSubtag.classList.remove(hideClassName);
+				}
+			}
+		}
+		
+		if (isSubtag) {
+			previousHeadingSubtag = elementSiteContainer;
+			previousHeadingSubtagHasVisibleInside = false;
+		}
+		else {
+			if (previousHeadingTag !== undefined) {
+				if (!previousHeadingTagHasVisibleInside) {
+					if (!previousHeadingTag.classList.contains(hideClassName)) {
+						previousHeadingTag.classList.add(hideClassName);
+					}
+				}
+				else {
+					if (previousHeadingTag.classList.contains(hideClassName)) {
+						previousHeadingTag.classList.remove(hideClassName);
+					}
+				}
+			}
+			
+			previousHeadingTag = elementSiteContainer;
+			previousHeadingSubtag = undefined;
+			previousHeadingTagHasVisibleInside = false;
+			previousHeadingSubtagHasVisibleInside = false;
+		}
+	};
+	
+	for (const elementSiteContainer of elementSitesContainer.children) {
+		let siteTags = elementSiteContainer.getAttribute("data-tags")?.split(",") ?? [];
+		if (siteTags.length === 1 && siteTags[0].length === 0) {
+			siteTags.length = 0;
+		}
+		if (siteTags.length === 0) {
+			if (elementSiteContainer.id.length > 0) {
+				ProcessHeader(elementSiteContainer);
+			}
+			continue;
+		}
+		siteTags = new Set(siteTags);
+		
+		let siteIsVisible = (
+			(tagsOn.size === 0 || Array.from(tagsOn).every((tagName) => siteTags.has(tagName)))
+			&& (tagsOff.size === 0 || Array.from(tagsOff).every((tagName) => !siteTags.has(tagName)))
+		);
+		const hideClassName = "hide-site";
+		if (siteIsVisible) {
+			previousHeadingTagHasVisibleInside = true;
+			if (previousHeadingSubtag !== undefined) {
+				previousHeadingSubtagHasVisibleInside = true;
+			}
+			if (elementSiteContainer.classList.contains(hideClassName)) {
+				elementSiteContainer.classList.remove(hideClassName);
+			}
+		}
+		else {
+			if (!elementSiteContainer.classList.contains(hideClassName)) {
+				elementSiteContainer.classList.add(hideClassName);
+			}
+		}
+	}
+	
+	ProcessHeader();
+}
+
+(function ()
+{
+	for (const element_action of document.querySelectorAll("input[type='checkbox'][indeterminate]")) {
+		element_action.indeterminate = true;
+		element_action.readOnly = true;
+	}
+	
+	// Trigger onload event in all input tags that define the event.
+	for (const element_action of document.querySelectorAll("input[onload]")) {
+		element_action.dispatchEvent(new Event("load"));
+	}
+	
+	ToggleTag();
+})();

--- a/package-lock.json
+++ b/package-lock.json
@@ -9,7 +9,6 @@
       "version": "1.0.0",
       "license": "ISC",
       "dependencies": {
-        "dotenv": "^16.3.1",
         "markdown": "^0.5.0",
         "marked": "^9.1.5",
         "yaml": "^2.3.4"
@@ -19,17 +18,6 @@
       "version": "1.1.1",
       "resolved": "https://registry.npmjs.org/abbrev/-/abbrev-1.1.1.tgz",
       "integrity": "sha512-nne9/IiQ/hzIhY6pdDnbBtz7DjPTKrY00P/zvPSm5pOFkl6xuGrGnXn/VtTNNfNtAfZ9/1RtehkszU9qcTii0Q=="
-    },
-    "node_modules/dotenv": {
-      "version": "16.3.1",
-      "resolved": "https://registry.npmjs.org/dotenv/-/dotenv-16.3.1.tgz",
-      "integrity": "sha512-IPzF4w4/Rd94bA9imS68tZBaYyBWSCE47V1RGuMrB94iyTOIEwRmVL2x/4An+6mETpLrKJ5hQkB8W4kFAadeIQ==",
-      "engines": {
-        "node": ">=12"
-      },
-      "funding": {
-        "url": "https://github.com/motdotla/dotenv?sponsor=1"
-      }
     },
     "node_modules/markdown": {
       "version": "0.5.0",
@@ -81,11 +69,6 @@
       "version": "1.1.1",
       "resolved": "https://registry.npmjs.org/abbrev/-/abbrev-1.1.1.tgz",
       "integrity": "sha512-nne9/IiQ/hzIhY6pdDnbBtz7DjPTKrY00P/zvPSm5pOFkl6xuGrGnXn/VtTNNfNtAfZ9/1RtehkszU9qcTii0Q=="
-    },
-    "dotenv": {
-      "version": "16.3.1",
-      "resolved": "https://registry.npmjs.org/dotenv/-/dotenv-16.3.1.tgz",
-      "integrity": "sha512-IPzF4w4/Rd94bA9imS68tZBaYyBWSCE47V1RGuMrB94iyTOIEwRmVL2x/4An+6mETpLrKJ5hQkB8W4kFAadeIQ=="
     },
     "markdown": {
       "version": "0.5.0",

--- a/sites.yml
+++ b/sites.yml
@@ -1,375 +1,495 @@
-- name: www.equestriadaily.com
+- name: Equestria Daily
+  link: www.equestriadaily.com
   description: A popular blog featuring a wide array of pony content.
-  img: 
+  tags: blog
   updated: 2023-11-08
-- name: www.derpibooru.org
+
+- name: Derpibooru
+  link: derpibooru.org
   description: A popular image board.
-  img: 
+  tags: art
   updated: 2023-11-08
-- name: manebooru.art
+
+- name: Manebooru
+  link: manebooru.art
   description: A popular alternative with more strict guidelines on controversial content.
-  img:
+  tags: art
   updated: 2023-11-09
-- name: www.horse-news.org
+
+- name: Horse News
+  link: www.horse-news.org
   description: A blog featuring troll-like articles about current events in the MLP fandom.
-  img: 
+  tags: blog
   updated: 2023-11-08
-- name: www.dailydoseofpony.com
+
+- name: Daily Dose of Pony
+  link: www.dailydoseofpony.com
   description: An all-skill-level content featuring platform for all kinds of pony content.
-  img:
+  tags: blog
   updated: 2023-11-09
-- name: www.fimfiction.net
+
+- name: Fimfiction
+  link: www.fimfiction.net
   description: A website dedicated to hosting MLP fanfics.
-  img: 
+  tags: fanfiction
   updated: 2023-11-08
-- name: mlp-france.com
-  no_https: True
-  description: France based community
-  img: 
+
+- name: MLP France
+  link: http://mlp-france.com
+  description: France based community.
+  tags: episode
   updated: 2023-11-08
-- name: www.whatisabrony.com
-  description: Fun site explaining what a brony is
-  img: 
+
+- name: What is a brony?
+  link: www.whatisabrony.com
+  description: Fun site explaining what a brony is.
+  tags: wiki
   updated: 2023-11-09
-- name: poniverse.net
+
+- name: Poniverse
+  link: poniverse.net
   description: Gateway site to the various poniverse webistes.
-  img: 
+  tags: directory
   updated: 2023-11-08
-- name: mlpforums.com
-  description: General purpose MLP forums website
-  img: 
+
+- name: MLP Forums
+  link: mlpforums.com
+  description: General purpose MLP forums website.
+  tags: forum
   updated: 2023-11-08
-- name: www.babscon.com
-  description: MLP convention based in San Francisco
-  img: 
+
+- name: BABSCon
+  link: www.babscon.com
+  description: MLP convention based in San Francisco.
+  tags: convention:usa
   updated: 2023-11-08
-- name: ponycon.info
-  description: Directory of MLP conventions and events with countdown clocks
-  img:
+
+- name: PonyCon Countdown
+  link: ponycon.info
+  description: Directory of MLP conventions and events with countdown clocks.
+  tags: directory,convention
   updated: 2023-11-09
-- name: ponyvilleciderfest.com
-  description: MLP convention based in Milwaukee 
-  img: 
+
+- name: Ponyville Ciderfest
+  link: ponyvilleciderfest.com
+  description: MLP convention based in Milwaukee.
+  tags: convention:usa
   updated: 2023-11-08
-- name: bronycan.ca
-  is_dead: True
-  description: Former MLP convention based in Canada
-  img: 
+
+- name: BronyCAN
+  link: bronycan.ca
+  description: Former MLP convention based in Canada.
+  tags: convention:canada,dead
   updated: 2023-11-08
-- name: everfreenw.com
-  description: MLP convention based in Seattle
-  img: 
+
+- name: Everfree Northwest
+  link: everfreenw.com
+  description: MLP convention based in Seattle.
+  tags: convention:usa
   updated: 2023-11-08
-- name: mlp-msp.com
-  description: Former MLP convention based in Minneapolis, site throwing errors
-  img: 
+
+- name: MLP-MSP
+  link: mlp-msp.com
+  description: Former MLP convention based in Minneapolis.
+  tags: convention:usa,dead
   updated: 2023-11-08
-- name: www.harmonycon.org
-  description: MLP convention based in Dallas, Texas
-  img: 
+
+- name: HarmonyCon
+  link: www.harmonycon.org
+  description: MLP convention based in Dallas, Texas.
+  tags: convention:usa
   updated: 2023-11-08
-- name: trotcon.net
-  description: MLP convention based in Ohio
-  img: 
+
+- name: TrotCon
+  link: trotcon.net
+  description: MLP convention based in Ohio.
+  tags: convention:usa
   updated: 2023-11-08
-- name: whinnycity.com
-  description: MLP convention based in Chicago
-  img: 
+
+- name: Whinny City Pony Con
+  link: whinnycity.com
+  description: MLP convention based in Chicago.
+  tags: convention:usa
   updated: 2023-11-08
-- name: seaponycon.com
-  description: Former MLP convention which used to take place on cruise ships
-  img: 
+
+- name: Project SEAPonyCon
+  link: seaponycon.com
+  description: Former MLP convention which used to take place on cruise ships.
+  tags: convention:online:international
   updated: 2023-11-08
-- name: www.aliconmlp.com
-  is_dead: True
-  description: Former MLP convention based in Australia
-  img: 
+
+- name: AliCon
+  link: www.aliconmlp.com
+  description: Former MLP convention based in Australia.
+  tags: convention:australia,dead
   updated: 2023-11-08
-- name: everfree-encore.eu
-  description: Yearly music festival organised in Germany
-  img:
+
+- name: Everfree Encore
+  link: everfree-encore.eu
+  description: Yearly music festival organised in Germany.
+  tags: convention:europe
   updated: 2023-11-09
-- name: eponafest.it
-  description: The Italian MLP convention
-  img:
+
+- name: EponaFest
+  link: eponafest.it
+  description: The Italian MLP convention.
+  tags: convention:europe
   updated: 2023-11-09
-- name: galacon.pony-events.eu
-  description: The largest European MLP convention, Germany
-  img:
+
+- name: GalaCon
+  link: galacon.pony-events.eu
+  description: The largest European MLP convention based in Germany.
+  tags: convention:europe
   updated: 2023-11-09
-- name: www.czequestria.cz
-  description: The Czech MLP convention
-  img:
+
+- name: Czequestria
+  link: www.czequestria.cz
+  description: The Czech MLP convention.
+  tags: convention:europe
   updated: 2023-11-09
-- name: ponyconholland.com
-  description: Dutch MLP convention
-  img:
+
+- name: PonyCon Holland
+  link: ponyconholland.com
+  description: Dutch MLP convention.
+  tags: convention:europe
   updated: 2023-11-09
-- name: ponyfest.horse
-  description: Online MLP convention
-  img: 
+
+- name: PonyFest
+  link: ponyfest.horse
+  description: Online MLP convention.
+  tags: convention:online
   updated: 2023-11-08
-- name: www.bronystate.net 
-  description: Populare brony streaming site; used to host MLP episode stream parties
-  img: 
+
+- name: Bronystate
+  link: bronystate.net
+  description: Popular brony streaming site which used to host MLP episode stream parties.
+  tags: stream
   updated: 2023-11-08
-- name: www.bronytv.net
-  description: ""
-  img: 
+
+- name: BronyTV
+  link: bronytv.net
+  description: A streaming site that hosts weekly Brony media stream parties.
+  tags: stream
+  updated: 2023-11-10
+
+- name: CinemaQuestria
+  link: cinemaquestria.com
+  description: A streaming site that frequently hosts various Brony media stream parties.
+  tags: stream
+  updated: 2023-11-10
+
+- name: Equestria.tv
+  link: equestria.tv
+  description: A real-time video and music sharing site for bronies. 
+  tags: stream,dead
+  updated: 2023-11-10
+
+- name: Pony.fm
+  link: pony.fm
+  description: MLP music hosting website.
+  tags: music
   updated: 2023-11-08
-- name: cinemaquestria.com
-  description: ""
-  img: 
+
+- name: Ponyville Live!
+  link: ponyvillelive.com
+  description: A music, video and show streaming network.
+  tags: music,stream
+  updated: 2023-11-10
+
+- name: The Pony Music Archive
+  link: ponemusic.net
+  description: A place to find the huge Pony Music Archive torrent.
+  tags: music,dead
+  updated: 2023-11-10
+
+- name: Horse Music Herald
+  link: horsemusicherald.com
+  description: MLP fanmusic promotional blog.
+  tags: blog
   updated: 2023-11-08
-- name: equestria.tv
-  is_dead: True
-  description: dead
-  img: 
+
+- name: Canterlot Avenue
+  link: canterlotavenue.com
+  description: Role-playing website and forum.
+  tags: game,forum
+  updated: 2023-11-10
+
+- name: Red Light Ponyville
+  link: www.redlightponyville.com
+  description: Adult forum for roleplaying as well as art.
+  tags: adult,game,forum
   updated: 2023-11-08
-- name: pony.fm
-  description: MLP music hosting website
-  img: 
+
+- name: Canterlot
+  link: www.canterlot.com
+  description: Role-playing forum.
+  tags: game,forum
   updated: 2023-11-08
-- name: ponyvillelive.com
-  is_dead: true
-  description: will update when not dead
-  img: 
+
+- name: Starlight Glimmer 2020
+  link: www.starlightglimmer2020.com
+  description: A USA campaign website for Starlight Glimmer.
+  tags: joke,dead
+  updated: 2023-11-10
+
+- name: Vylet Pony
+  links:
+  - link: www.vyletpony.com
+    description: Personal website for Vylet Pony.
+  - link: trixielulamoon.com
+    description: Vylet Pony's secondary site.
+  - link: antonymph.com
+    description: Website for antonymph.
+  - link: cutiemarks.net
+    description: Website for Vylet Pony's album, Cutiemarks.
+  - link: starshipponyville.com
+    description: Vylet Pony website featuring her music.
+  tags: personal,music
   updated: 2023-11-08
-- name: ponemusic.net
-  description: I think there's supposed to be music here
-  img: 
+
+- name: Celestianism - The Celestial Religion
+  link: celestianism.com
+  description: Celestia-based religion site.
+  tags: joke,forum,dead
   updated: 2023-11-08
-- name: horsemusicherald.com
-  description: MLP fanmusic promotional blog
-  img: 
-  updated: 2023-11-08
-- name: canterlotavenue.com
-  description: Role-playing website
-  img: 
-  updated: 2023-11-08
-- name: www.redlightponyville.com
-  is_adult: true
-  description: Adult forum for roleplaying as well as art
-  img: 
-  updated: 2023-11-08
-- name: www.canterlot.com
-  description: Role-playing forum
-  img: 
-  updated: 2023-11-08
-- name: www.starlightglimmer2020.com
-  is_dead: true
-  description: Campaign website for Starlight Glimmer
-  img: 
-  updated: 2023-11-08
-- name: starshipponyville.com
-  description: Vylet Pony website featuring her music
-  img: 
-  updated: 2023-11-08
-- name: celestianism.com
-  is_dead: True
-  description: Celestia-based religion site
-  img: 
-  updated: 2023-11-08
-- name: greattobedifferent.com
-  is_dead: True
-  description: Companion site to Forest Rain's song
-  img:
+
+- name: It's Great to be Different
+  link: greattobedifferent.com
+  description: Companion site to Forest Rain's song.
+  tags: personal,blog,dead
   updated: 2023-11-09
-- name: www.tsssf.net
-  description: Website for playing Twilight Sparkle's secret shipfic folder
-  img: 
+
+- name: Twilight Sparkle's Secret Shipfic Folder Online
+  link: tsssf.net
+  description: Website for playing Twilight Sparkle's secret shipfic folder.
+  tags: game
   updated: 2023-11-08
-- name: poniarcade.com
-  description: Arcade website? Looks like it's down right now
-  img: 
+
+- name: Poniarcade
+  link: poniarcade.com
+  description: MLP themed Minecraft server.
+  tags: game,dead
+  updated: 2023-11-10
+
+- name: Equestria Gaming
+  link: www.equestriagaming.net
+  description: Blog promoting various MLP fan games.
+  tags: game,blog
   updated: 2023-11-08
-- name: www.equestriagaming.net
-  description: Blog promoting various MLP fan games
-  img: 
+
+- name: Children of Kefentse
+  link: childrenofkefentse.com
+  description: Fan community for TSSSF.
+  tags: game,forum
   updated: 2023-11-08
-- name: childrenofkefentse.com
-  description: Fan community for TSSSF
-  img: 
+
+- name: Pony Town
+  link: pony.town
+  description: Online multiplayer game where you can make your own custom pony and build a town.
+  links:
+  - link: event.pony.town
+    description: 
+  - link: eventblue.pony.town
+    description: 
+  - link: eventgreen.pony.town
+    description: 
+  - link: breezy.pony.town
+    description: 
+  tags: game
   updated: 2023-11-08
-- name: pony.town
-  description: Online multiplayer game where you can make your own custom pony + build a town
-  img: 
+
+- name: Twilight Sparkle's Secret Shipfic Folder
+  link: http://www.secretshipfic.com
+  description: Official website for Twilight Sparkle's secret shipfic folder.
+  tags: game
   updated: 2023-11-08
-- name: www.secretshipfic.com
-  no_https: true
-  description: Official website for Twilight Sparkle's secret shipfic folder
-  img: 
+
+- name: My Little Karaoke
+  link: www.mylittlekaraoke.com
+  description: Project website for the My Little Karaoke game.
+  tags: game,forum
   updated: 2023-11-08
-- name: www.mylittlekaraoke.com
-  description: Project website for the My Little Karaoke game
-  img: 
+
+- name: Ponytone
+  link: ponytone.online
+  description: Online version of My Little Karaoke which you can play with your friends.
+  tags: game
   updated: 2023-11-08
-- name: ponytone.online
-  description: Online version of My Little Karaoke which you can play with your friends
-  img: 
+
+- name: Cards Against Equestria
+  link: cardsagainstequestria.horse
+  description: MLP themed cards against humanity.
+  links:
+  - link: github.com/Rylius/CardsAgainstEquestria
+    description: Archived source code behind website game. Discontinued, outdated, unsupported.
+  tags: game,adult,dead
   updated: 2023-11-08
-- name: www.cardsagainstequestria.horse
-  is_adult: true
-  is_dead: true
-  description: MLP themed cards against humanity. https://github.com/Rylius/CardsAgainstEquestria
-  img: 
+
+- name: Canterlot Comics
+  link: www.canterlotcomics.com
+  description: Comic hosting website.
+  tags: comic
   updated: 2023-11-08
-- name: www.canterlotcomics.com
-  description: Comic hosting website
-  img: 
+
+- name: Pony Fiction Archive
+  link: ponyfictionarchive.net
+  description: Fanfiction archive website.
+  tags: fanfiction,archive,dead
   updated: 2023-11-08
-- name: www.ponyfictionarchive.net
-  is_dead: true
-  description: Fanfiction website
-  img: 
-  updated: 2023-11-08
-- name: www.theponyarchive.com
-  description: Archival website with tons of youtube videos hosted there
-  img: 
-  updated: 2023-11-08
-- name: fedi.ponysearch.eu
-  description: A quick start guide and instance list in multiple languages
-  img:
+
+- name: The Pony Archive
+  link: theponyarchive.com
+  description: Archival website including games, music and tons of youtube videos.
+  tags: archive
+  updated: 2023-11-10
+
+- name: Fedi Ponies
+  link: fedi.ponysearch.eu
+  description: A multilingual Brony Fediverse instance quick start guide.
+  tags: directory
   updated: 2023-11-09
-- name: www.bbbff.net
-  is_dead: true
-  description: Joke website for the band, Ben, Ben, Ben, Francis and Francis from Friendship is Witchcraft
-  img: 
+
+- name: "* B B B F F"
+  link: www.bbbff.net
+  description: Joke website for the band, Ben, Ben, Ben, Francis and Francis from Friendship is Witchcraft.
+  tags: joke,dead
   updated: 2023-11-08
-- name: mylittlegamedev.com
-  is_dead: true
-  description: Not sure what used to be here
-  img: 
+
+- name: My Little Game Dev
+  link: http://mylittlegamedev.com
+  description: A Brony game development forum.
+  tags: game,forum,dead
   updated: 2023-11-08
-- name: bronyshow.com
-  is_dead: true
-  description: ""
-  img: 
+
+- name: BronyShow
+  link: bronyshow.com
+  description: Brony podcast blog.
+  tags: blog,dead
+  updated: 2023-11-10
+
+- name: PonyvilleFM
+  link: ponyvillefm.com
+  description: Pony music radio.
+  tags: stream,music
   updated: 2023-11-08
-- name: ponyvillefm.com
-  description: Pony music radio
-  img: 
-  updated: 2023-11-08
-- name: www.vyletpony.com
-  description: Personal website for Vylet Pony
-  img: 
-  updated: 2023-11-08
-- name: cutiemarks.net
-  description: Website for Vylet Pony's album, Cutiemarks
-  img: 
-  updated: 2023-11-08
-- name: antonymph.com
-  description: Website for antonymph
-  img: 
-  updated: 2023-11-08
-- name: trixielulamoon.com
-  description: Vylet Pony's secondary site
-  img: 
-  updated: 2023-11-08
-- name: www.littleshyfim.com
-  description: LittleshyFiM's personal homepage
-  img:
+
+- name: LittleshyFiM
+  link: www.littleshyfim.com
+  description: LittleshyFiM's personal homepage.
+  tags: personal
   updated: 2023-11-09
-- name: boards.4channel.org/mlp/
-  is_adult: true
+
+- name: /mlp/ - Pony - 4Chan
+  link: boards.4channel.org/mlp/
   description: Anonymous image board. Birthplace of the fandom.
-  img: 
+  tags: adult,forum,art
   updated: 2023-11-08
-- name: pony.community  
+
+- name: pony.community
+  link: pony.community
   description: Site used to host the "Share your stuff" panel and renegade stage.
-  img: 
+  tags: blog,convention
   updated: 2023-11-09
-- name: www.ministryofimage.net
-  description: Fanfiction print shop
-  img: 
+
+- name: Pony Books | Ministry of Image
+  link: www.ministryofimage.net
+  description: Fanfiction print shop.
+  tags: fanfiction
   updated: 2023-11-09
-- name: sogreatandpowerful.com
-  description: Archival backup of SGAP's music
-  img: 
+
+- name: SoGreatandPowerful
+  link: sogreatandpowerful.com
+  description: Archival backup of SGAP's music.
+  tags: personal,archive,music
   updated: 2023-11-09
-- name: ponies.equestria.horse
-  description: Not sure what kind of community this is
-  img: 
+
+- name: Equestria.dev
+  link: equestria.dev
+  description: Repository of various code projects.
+  links:
+  - link: ponies.equestria.horse
+    description: 
+  tags: directory,tech
   updated: 2023-11-09
-- name: equestria.dev
-  description: Repository of various code projects
-  img: 
+
+- name: "#ponydev"
+  link: pony.dev
+  description: Community of software developer MLP fans.
+  tags: tech
   updated: 2023-11-09
-- name: pony.dev
-  description: Community of software developer MLP fans
-  img: 
+
+- name: PonyLatino
+  link: www.ponylatino.com
+  description: Community of Spanish-speaking MLP fans.
+  tags: episode,comic,blog
   updated: 2023-11-09
-- name: www.ponylatino.com
-  description: Community of Spanish-speaking MLP fans
-  img: 
-  updated: 2023-11-09
+
 - name: noise.horse
-  description: Former experimental music promotion website
-  img: 
+  link: noise.horse
+  description: Former experimental music promotion website.
+  tags: music,blog
   updated: 2023-11-09
-- name: ponymusic.wiki
-  description: Wiki of MLP songs, artists, and albums
-  img: 
+
+- name: Pony Music Wiki
+  link: ponymusic.wiki
+  description: Wiki of MLP songs, artists, and albums.
+  tags: wiki,music
   updated: 2023-11-09
-- name: mlp.fandom.com
+
+- name: "MLP:FIM Wiki | Fandom"
+  link: mlp.fandom.com
   description: Wiki for official MLP content.
-  img: 
+  tags: wiki
   updated: 2023-11-09
-- name: mlpfanart.fandom.com
+
+- name: MLP Fan Labor Wiki | Fandom
+  link: mlpfanart.fandom.com
   description: Wiki for MLP fan projects, artists, musicians, and more.
-  img: 
+  tags: wiki
   updated: 2023-11-09
-- name: www.bronibooru.com
+
+- name: Bronibooru
+  link: http://bronibooru.com
   description: Former image board.
-  img: 
-  updated: 2023-11-09
-- name: www.roundstable.com
-  description: Forum site
-  img: 
-  updated: 2023-11-09
-- name: marefair.org
-  description: Controversial 18+ MLP convention. Unknown if they will return.
-  img: 
-  updated: 2023-11-09
-- name: ponepaste.org
-  description: MLP text hosting service similar to pastebin
-  img: 
-  updated: 2023-11-09
-- name: projectvinyl.net
-  description: MLP video hosting website
-  img: 
-  updated: 2023-11-09
-- name: mlponies.com
-  description: Redirect to roundstable.com
-  img: 
-  updated: 2023-11-09
-- name: lighttheunicorn.horse 
-  description: Mastodon host for Light the Unicorn
-  img: 
-  updated: 2023-11-09
-- name: 
-  description: 
-  img: 
-  updated: 2023-11-09
-- name: 
-  description: 
-  img: 
-  updated: 2023-11-09
-- name: 
-  description: 
-  img: 
-  updated: 2023-11-09
-- name: 
-  description: 
-  img: 
+  tags: art
   updated: 2023-11-09
 
+- name: The Round Stable
+  link: roundstable.com
+  description: Forum site.
+  links:
+  - link: mlponies.com
+    description: 
+  tags: forum
+  updated: 2023-11-09
 
+- name: Mare Fair
+  link: marefair.org
+  description: 18+ MLP convention based in Orlando, Florida.
+  links:
+  - link: marefair.horse
+    description: 
+  - link: reg.marefair.org
+    description: 
+  - link: twitter.com/MareFairCon
+    description: Official X/Twitter account.
+  tags: adult,convention:usa
+  updated: 2023-11-09
 
+- name: PonePaste
+  link: ponepaste.org
+  description: MLP text hosting service similar to pastebin.
+  tags: tech
+  updated: 2023-11-09
 
+- name: Project Vinyl
+  link: projectvinyl.net
+  description: MLP video hosting website.
+  tags: archive
+  updated: 2023-11-09
 
-
-
-
-
-  
+- name: Light's Hay Stash
+  link: lighttheunicorn.horse
+  description: Mastodon host for Light the Unicorn.
+  tags: tech
+  updated: 2023-11-09

--- a/tags.yml
+++ b/tags.yml
@@ -1,0 +1,70 @@
+- tag: dead
+  name: Dead Site
+  description: Old websites that are no longer available or active.
+- tag: adult
+  name: Adult
+  description: Adults and mature audiences only. NSFW (Not Safe For Work) content.
+- tag: blog
+  name: Blog
+  description: 
+- tag: wiki
+  name: Wiki
+  description: A source of information.
+- tag: art
+  name: Art
+  description: 
+- tag: music
+  name: Music
+  description: 
+- tag: fanfiction
+  name: Fanfiction
+  description: 
+- tag: game
+  name: Gaming
+  description: Board, video and social games.
+- tag: episode
+  name: Episodes
+  description: Hosts MLP episodes.
+- tag: comic
+  name: Comics
+  description: 
+- tag: tech
+  name: Tech
+  description: 
+- tag: archive
+  name: Archive
+  description: 
+- tag: joke
+  name: Joke
+  description: Websites made primarily as a joke.
+- tag: other
+  name: Other
+  description: Other sites that don't fit into general categories.
+- tag: convention
+  name: Conventions, Fairs, Festivals and Meet-ups
+  description: 
+  subtags:
+  - tag: usa
+    name: USA
+  - tag: canada
+    name: Canada
+  - tag: europe
+    name: Europe
+  - tag: international
+    name: International
+  - tag: online
+    name: Online
+  - tag: australia
+    name: Australia
+- tag: forum
+  name: Forum
+  description: 
+- tag: stream
+  name: Streaming
+  description: Online video and audio streaming platforms.
+- tag: directory
+  name: Directory
+  description: Directory websites that list other MLP/Brony content.
+- tag: personal
+  name: Personal
+  description: A website dedicated to a specific or group of individuals.


### PR DESCRIPTION
I was gonna ad some more sites but I didn't like the way sites were organised and that some could be under multiple categories. So I made a tagging checkbox system. I haven't added the sites I was gonna yet as already during development some that I was gonna was already added and I'm rushing to get this reorganisation out.

Since you added the Table of Contents commit before I finished this feature, this PR is behind by 1 commit. I have however updated the sites.yml with all the new entries as seen in f0a1fc9daa190f41d7fa095e9ae0bab5e14ca11c.
Additionally I don't know what you were planning to do with adult content so I made the build script output a separate html page with has adult sites in it.
I didn't include the `img:` yml property as we're not using it yet and their all empty.
TODO: The README.md needs updating with the new format in sites.yml and tags.yml.
TODO: `index.html?tags-on=convention:online&tags-off=dead` Want to do GET url arguments so tag checkboxes can be saved. In this example `dead` `Dead Site` is unchecked while `convention:online` Online conventions are checked. So the only result with the current dataset is PonyFest.

I hope you like this alternative system.