### PR TITLE
Add spib.no

### DIFF
--- a/directory.yml
+++ b/directory.yml
@@ -246,6 +246,7 @@ body:
       - site: tsibp.com
       - site: mare.biz
       - site: bestest.horse
+      - site: spib.no
   - group: Personal Sites
     children:
       - site: www.littleshyfim.com

--- a/sites.yml
+++ b/sites.yml
@@ -966,3 +966,9 @@
   description: Livestreams conventions from around the world.
   tags: convention,stream
   updated: 2023-11-30
+
+- name: Spib
+  link: spib.no
+  description: Spitfire = Spib
+  tags: art,joke
+  updated: 2023-12-19


### PR DESCRIPTION
Adds [spib.no](https://spib.no/), a joke site/fansite of Spitfire by https://github.com/Simple2Sample